### PR TITLE
Fix CSS to avoid removing bullets to all lists

### DIFF
--- a/_extensions/quiz/quiz.css
+++ b/_extensions/quiz/quiz.css
@@ -1,10 +1,10 @@
-.reveal ul {
+.reveal .quiz-question ul {
     display: block;
     list-style-type: none;
     padding-left: 0;
 }
 
-.reveal li {
+.reveal .quiz-question li {
     margin-bottom: 15px;
 }
 


### PR DESCRIPTION
The previous CSS changed the style of all lists by using `.reveal ul` and removed the bullet points by setting `list-style-type: none`. This commit changes the CSS selector by adding `.quiz-question` to ensure that only the lists in a Quiz slide are changed.